### PR TITLE
Make kebab/nest options regexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,15 @@ The main fn provided is the `overlay` function which takes in a map and applies 
  {:host "localhost", :username "user", :password "insecure"}}
 ```
 `overlay` can also take an options map which change its behavior:
-- `kebab-char`: a string/char that indicates a `-` between two words in a single key
-- `nest-char`: a string/char that indicates a new level of nesting as been added
-- `path-fn`: is called for every part 
+- `kebab-re`: a string/char that indicates a `-` between two words in a single key
+- `nest-re`: a string/char that indicates a new level of nesting as been added
+- `path-fn`: is called for every part
 ```clojure
 ;; Given this (arbitrary and super confusing yet explanatory) env:
 ;;   CLUSTERSv0vHOST.NAME=localhost
 (env/overlay {:clusters [{:host-name nil}]
-             {:kebab-char "."
-              :nest-char "v"
+             {:kebab-re #"\."
+              :nest-re #"v"
               :path-fn #(try
                           (Integer/parseInt %)
                           (catch Exception _
@@ -65,8 +65,8 @@ Loads the given resource (defaulting to `config.edn`) and calls `overlay` on the
 
 ;; It's me again!:
 ;;   CLUSTERSv0vHOST.NAME=localhost
-(env/load-config "cluster.edn" {:kebab-char "."
-                                :nest-char "v"
+(env/load-config "cluster.edn" {:kebab-re #"\."
+                                :nest-re #"v"
                                 :path-fn #(try
                                             (Integer/parseInt %)
                                             (catch Exception _

--- a/src/edn_env/core.clj
+++ b/src/edn_env/core.clj
@@ -5,8 +5,8 @@
 
 (def default-config-file "config.edn")
 (def default-options {:path-fn keyword
-                      :kebab-char "_"
-                      :nest-char "__"})
+                      :kebab-re #"_"
+                      :nest-re #"__"})
 
 (defn- impartial
   "The opposite of `partial`.
@@ -31,10 +31,10 @@
   "Converts a env var name into a path suitable for `get-in`."
   ([var]
    (var->path var default-options))
-  ([var {:keys [kebab-char nest-char path-fn]}]
-   (let [->pattern #(get {"." #"\."} (str %) (re-pattern (str %)))
-         parts (str/split (str/lower-case var) (->pattern nest-char))]
-     (map (comp path-fn (impartial str/replace (->pattern kebab-char) "-")) parts))))
+  ([var options]
+   (let [{:keys [kebab-re nest-re path-fn]} (merge default-options options)
+         parts (str/split (str/lower-case var) nest-re)]
+     (map (comp path-fn (impartial str/replace kebab-re "-")) parts))))
 
 (defn parse-value
   "Parses an env value using `edn/read-string`.

--- a/test/edn_env/core_test.clj
+++ b/test/edn_env/core_test.clj
@@ -22,10 +22,10 @@
     "ONE_TWO" [:one-two] sut/default-options
     "ONE__TWO" [:one :two] sut/default-options
     "ONE__TWO_THREE_FOUR" [:one :two-three-four] sut/default-options
-    "ONE_TWO" [:one :two] (assoc sut/default-options :nest-char "_")
+    "ONE_TWO" [:one :two] (assoc sut/default-options :nest-re #"_")
     "ONE_TWO.THREE" [:one :two-three] (assoc sut/default-options
-                                             :nest-char \_
-                                             :kebab-char \.)
+                                             :nest-re #"_"
+                                             :kebab-re #"\.")
     "ONE__2__THREE" [:one 2 :three] (assoc sut/default-options
                                            :path-fn #(try
                                                        (Long/parseLong %)
@@ -69,8 +69,8 @@
     (testing "overriding defaults"
       (is (= {:our-clusters [{:url "http://somewhere"}]}
              (sut/load-config "other-config.edn"
-                              {:kebab-char "."
-                               :nest-char "_"
+                              {:kebab-re #"\."
+                               :nest-re #"_"
                                :path-fn #(try
                                            (Long/parseLong %)
                                            (catch Exception _


### PR DESCRIPTION
- This avoids the awkward `(->pattern)` paradigm and makes the key
  name's much more applicable (before `-char` could _also_ be a
  string, etc).